### PR TITLE
Corretto escaping single quotes in 'GetComuni' (es: L'Aquila).

### DIFF
--- a/ajax_get_ente_locale.php
+++ b/ajax_get_ente_locale.php
@@ -71,7 +71,8 @@ function GetComuni($provincia,$connect)
   //se provincia non è null, recupera id della provincia e seleziona tutte i comuni della regione.
   if(isset($provincia))
   {
-    $queryIdProvincia="SELECT id_pro FROM province WHERE nome_provincia='$provincia'";
+    $fixed_provincia = mysqli_real_escape_string($connect, $provincia);
+    $queryIdProvincia="SELECT id_pro FROM province WHERE nome_provincia='$fixed_provincia'";
     $result=mysqli_query($connect,  $queryIdProvincia) or die("<b>Errore:</b> Impossibile eseguire la query id provincia");
     while ($row = mysqli_fetch_row($result))
     {


### PR DESCRIPTION
Abito in provincia dell'Aquila, e mi sono accorto di non poter selezionare i comuni della mia provincia.

Per questa ragione ho apportato la correzione necessaria alla funzione GetComuni.

Ho notato purtroppo che lo stesso problema è presente in tutte le funzioni che richiedono l'inserimento di un dato testuale. Ciò può essere causa, oltre che dell'ovvio malfunzionamento del software, anche di un **possibile attacco di tipo SQL Injection**. Se avrò tempo a disposizione, e se nessuno lo farà prima di me, cercherò di apportare e proporre le necessarie modifiche.